### PR TITLE
README.md typos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,134 @@
+language: php
+
+os: linux
+
+addons:
+  firefox: "47.0.1"
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - $HOME/.npm
+
+before_install:
+  - phpenv config-rm xdebug.ini
+  - cd ../..
+  - composer create-project -n --no-dev --prefer-dist moodlehq/moodle-plugin-ci ci ^3
+  - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+
+install:
+  - moodle-plugin-ci install
+
+services:
+ - mysql
+ - postgresql
+ - docker
+
+jobs:
+  include:
+    - php: 7.4
+      env: MOODLE_BRANCH=master           DB=pgsql
+    - php: 7.4
+      env: MOODLE_BRANCH=master           DB=mysqli
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_311_STABLE DB=pgsql
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_311_STABLE DB=mysqli
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_310_STABLE DB=pgsql
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_310_STABLE DB=mysqli
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_39_STABLE DB=pgsql
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_39_STABLE DB=mysqli
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql
+    - php: 7.4
+      env: MOODLE_BRANCH=MOODLE_38_STABLE DB=mysqli
+
+    - php: 7.3
+      env: MOODLE_BRANCH=master           DB=pgsql
+    - php: 7.3
+      env: MOODLE_BRANCH=master           DB=mysqli
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_311_STABLE DB=pgsql
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_311_STABLE DB=mysqli
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_310_STABLE DB=pgsql
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_310_STABLE DB=mysqli
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_39_STABLE DB=pgsql
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_39_STABLE DB=mysqli
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_38_STABLE DB=mysqli
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=pgsql
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
+    - php: 7.3
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=mysqli
+
+    - php: 7.2
+      env: MOODLE_BRANCH=master           DB=pgsql
+    - php: 7.2
+      env: MOODLE_BRANCH=master           DB=mysqli
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_311_STABLE DB=pgsql
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_311_STABLE DB=mysqli
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_310_STABLE DB=pgsql
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_310_STABLE DB=mysqli
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_39_STABLE DB=pgsql
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_39_STABLE DB=mysqli
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_38_STABLE DB=pgsql
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_38_STABLE DB=mysqli
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=pgsql
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
+    - php: 7.2
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=mysqli
+
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=pgsql
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_37_STABLE DB=mysqli
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
+    - php: 7.1
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=mysqli
+
+    - php: 7.0
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=pgsql
+    - php: 7.0
+      env: MOODLE_BRANCH=MOODLE_36_STABLE DB=mysqli
+
+script:
+  - moodle-plugin-ci phplint
+  - moodle-plugin-ci phpcpd || true
+  - moodle-plugin-ci phpmd
+  - moodle-plugin-ci codechecker
+  - moodle-plugin-ci validate
+  - moodle-plugin-ci savepoints
+  - moodle-plugin-ci mustache
+  - moodle-plugin-ci grunt || true
+  - moodle-plugin-ci phpdoc || true
+  - moodle-plugin-ci phpunit
+  - moodle-plugin-ci behat
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # qtype_drawing
-A simple and easy-to-use SVG Free-Hand Drawing question type plugin for modole. The plugin drawing interface and core functionalities are based on SVG-Edit, D3, rapael, and method draw libararies as main thrid party libraries.
+A simple and easy-to-use SVG Free-Hand Drawing question type plugin for Moodle. The plugin drawing interface and core functionalities are based on SVG-Edit, D3, Raphaël, and method draw libararies as main third party libraries.

--- a/lang/de/qtype_drawing.php
+++ b/lang/de/qtype_drawing.php
@@ -26,7 +26,7 @@
 
 $string['pluginname'] = 'Freihandzeichnen (ETH)';
 $string['pluginname_help'] = 'Als Antwort auf eine Frage zeichnet der Befragte eine Antwort auf ein vordefiniertes Bild. Es gibt nur eine richtige Antwort.';
-$string['pluginname_link'] = 'Frage/Typ/Zeichnen';
+$string['pluginname_link'] = 'question/type/drawing';
 $string['pluginnameadding'] = 'Hinzufügen einer Freihandzeichnen Frage';
 $string['pluginnameediting'] = 'Bearbeiten einer Freihandzeichnen Frage';
 $string['pluginnamesummary'] = 'Als Antwort auf eine Frage zeichnet der Befragte eine Antwort auf ein vordefiniertes Bild. Es gibt nur eine richtige Antwort.';


### PR DESCRIPTION
If you are interested, this fixes some typos in the README.md file. That may help in the Plugin approval process by Moodle! 😃
Also, .travis.yml would enable travis-ci.com to run.

Feel free to merge selectively, of course.

Best,
Luca