### PR TITLE
add missing curly braces to fix syntax errors in phpunit test

### DIFF
--- a/tests/walkthrough_test.php
+++ b/tests/walkthrough_test.php
@@ -57,7 +57,7 @@ class qtype_drawing_walkthrough_testcase extends qbehaviour_walkthrough_test_bas
         // Submit something that must not validate - missing ggbbase64...
         $this->process_submission(
                                 array(
-                                'answer' => 'DRAWING');
+                                'answer' => 'DRAWING'));
         // Verify.
         $this->check_current_state(question_state::$complete);
         $this->check_current_mark(null);
@@ -66,7 +66,7 @@ class qtype_drawing_walkthrough_testcase extends qbehaviour_walkthrough_test_bas
                                     $this->get_no_hint_visible_expectation());
         // Submit something that must not validate - wrong responsestring: must only contain 0 and 1.
         $this->process_submission(
-                                array('answer' => 'DRAWING');
+                                array('answer' => 'DRAWING'));
         $this->check_current_state(question_state::$complete);
         $this->check_current_mark(null);
         $this->check_current_output($this->get_contains_marked_out_of_summary(), $this->get_does_not_contain_feedback_expectation(),
@@ -74,7 +74,7 @@ class qtype_drawing_walkthrough_testcase extends qbehaviour_walkthrough_test_bas
                                     $this->get_no_hint_visible_expectation());
         // Now put in the right answer.
         $this->process_submission(
-                                array('answer' => 'DRAWING');
+                                array('answer' => 'DRAWING'));
         $this->check_current_state(question_state::$complete);
         $this->check_current_mark(null);
         $this->check_current_output($this->get_contains_marked_out_of_summary(), $this->get_does_not_contain_feedback_expectation(),


### PR DESCRIPTION
Following errors occur without curly braces when running phpunit test for 'walkthrough_test.php'

stderr: 'PHP Parse error: syntax error, unexpected '';'', expecting '')'' in /var/www/html/question/type/drawing/tests/walkthrough_test.php on line 60'
stderr: 'PHP Parse error: syntax error, unexpected '';'', expecting '')'' in /var/www/html/question/type/drawing/tests/walkthrough_test.php on line 69'
stderr: 'PHP Parse error: syntax error, unexpected '';'', expecting '')'' in /var/www/html/question/type/drawing/tests/walkthrough_test.php on line 77'