### PR TITLE
issue31  Update Simonetta font file format

### DIFF
--- a/css/fonts.css
+++ b/css/fonts.css
@@ -48,7 +48,7 @@
 }
 @font-face {
     font-family: 'Simonetta';
-    src: url('font-files/simonetta-italic-webfont.woff') format('woff');
+    src: url('font-files/simonetta-italic-webfont.ttf') format('ttf');
     font-weight: normal;
     font-style: italic;
 }

--- a/thirdpartylibs.xml
+++ b/thirdpartylibs.xml
@@ -120,7 +120,7 @@
         <licenseversion></licenseversion>
     </library> 
     <library>
-        <location>css/font-files/simonetta-italic-webfont.woff</location>
+        <location>css/font-files/simonetta-italic-webfont.ttf</location>
         <name>Simonetta Italic</name>
         <version></version>
         <license>SIL Open Font License (OFL)</license>


### PR DESCRIPTION
Replaced the Simonetta Italic font from WOFF to TTF format for consistency and compatibility. Updated both the CSS and the thirdpartylibs.xml file to reflect this change.

related to https://github.com/ethz-let/moodle-qtype_drawing/issues/31