### PR TITLE
CTP-5509: Tidy PHPUnit tests

### DIFF
--- a/tests/helper.php
+++ b/tests/helper.php
@@ -21,9 +21,11 @@
  * @copyright 2019 ETH Zurich
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
 defined('MOODLE_INTERNAL') || die();
 global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
+require_once($CFG->dirroot . '/question/type/drawing/questiontype.php');
 
 /**
  * Test helper class for the drawing question type.

--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -23,11 +23,19 @@
  * @copyright 2020 ETH Zurich
  * @license http://www.drawing.org/license
  */
+
+namespace qtype_drawing;
+
+use advanced_testcase;
+use qtype_drawing_question;
+use question_bank;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
 require_once($CFG->dirroot . '/question/type/drawing/question.php');
+require_once($CFG->dirroot . '/question/type/drawing/questiontype.php');
 
 /**
  * Unit tests for the drawing question definition class.
@@ -35,7 +43,7 @@ require_once($CFG->dirroot . '/question/type/drawing/question.php');
  * @copyright 2020 ETH Zurich
  * @license http://www.drawing.org/license
  */
-class qtype_drawing_question_test extends advanced_testcase {
+class question_test extends advanced_testcase {
 
     public function test_get_question_summary() {
         question_bank::load_question_definition_classes('drawing');

--- a/tests/questiontype_test.php
+++ b/tests/questiontype_test.php
@@ -23,6 +23,11 @@
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+namespace qtype_drawing;
+
+use advanced_testcase;
+use qtype_drawing;
+use stdClass;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -38,7 +43,7 @@ require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
  * @copyright  2018 ETH Zurich
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_drawing_test extends advanced_testcase {
+class questiontype_test extends advanced_testcase {
     protected $qtype;
 
     protected function setUp(): void {

--- a/tests/walkthrough_test.php
+++ b/tests/walkthrough_test.php
@@ -21,6 +21,13 @@
  * @copyright 2020 ETH Zurich
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
+
+namespace qtype_drawing;
+
+use qbehaviour_walkthrough_test_base;
+use question_state;
+use test_question_maker;
+
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
@@ -32,7 +39,7 @@ require_once($CFG->dirroot . '/question/engine/tests/helpers.php');
  * @copyright 2013 The Open University
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class qtype_drawing_walkthrough_testcase extends qbehaviour_walkthrough_test_base {
+class walkthrough_test extends qbehaviour_walkthrough_test_base {
 
     public function test_deferred_feedback_plain_text() {
 


### PR DESCRIPTION
Align PHPUnit test class names with filenames
namespace to ensure uniqueness
add missing require once

The tests currently break in certain scenarios, this resolves that.